### PR TITLE
Add Auth#test

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ client.channels.invite(channel_id, user_id) # invites the specific user to the s
 
 ### IM
 
-### OAuth
+### Auth
+
+client.auth.test # get info about a specific oauth token
 
 ### Presence
 

--- a/lib/laziness.rb
+++ b/lib/laziness.rb
@@ -1,6 +1,7 @@
 require 'laziness/version'
 require 'laziness/api'
 require 'laziness/base'
+require 'laziness/auth'
 require 'laziness/channel'
 require 'laziness/client'
 require 'laziness/errors'

--- a/lib/laziness/api.rb
+++ b/lib/laziness/api.rb
@@ -1,5 +1,6 @@
 require 'httparty'
 
 require 'laziness/api/base'
+require 'laziness/api/auth'
 require 'laziness/api/channels'
 require 'laziness/api/users'

--- a/lib/laziness/api/auth.rb
+++ b/lib/laziness/api/auth.rb
@@ -1,0 +1,10 @@
+module Slack
+  module API
+    class Auth < Base
+      def test
+        response = request :get, access_token, 'auth.test'
+        Slack::Auth.parse response
+      end
+    end
+  end
+end

--- a/lib/laziness/auth.rb
+++ b/lib/laziness/auth.rb
@@ -1,0 +1,4 @@
+module Slack
+  class Auth < Base
+  end
+end

--- a/spec/laziness/api/auth_spec.rb
+++ b/spec/laziness/api/auth_spec.rb
@@ -1,0 +1,13 @@
+describe Slack::API::Auth do
+  let(:access_token) { "12345" }
+  subject { Slack::API::Auth.new access_token }
+
+  describe '.test' do
+    it 'returns the status of the authentication token' do
+      stub_slack_request :get, "auth.test?token=#{access_token}", 'auth_test.json'
+
+      auth = subject.test
+      expect(auth.ok).to eq true
+    end
+  end
+end

--- a/spec/support/fixtures/auth_test.json
+++ b/spec/support/fixtures/auth_test.json
@@ -1,0 +1,8 @@
+{
+  "ok": true,
+  "url": "https:\/\/tour.slack.com\/",
+  "team": "tour",
+  "user": "jimmy",
+  "team_id": "T024BLAH",
+  "user_id": "U024BLAH"
+}


### PR DESCRIPTION
This adds the wrappers around [`Auth#test`](https://api.slack.com/methods/auth.test) which allows Slack to test the validity of a certain access token.
