### PR TITLE
Change the VERSION wrapper to Laziness

### DIFF
--- a/laziness.gemspec
+++ b/laziness.gemspec
@@ -5,7 +5,7 @@ require 'laziness/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "laziness"
-  spec.version       = Slack::VERSION
+  spec.version       = Laziness::VERSION
   spec.authors       = ["Jamie Wright"]
   spec.email         = ["jamie@brilliantfantastic.com"]
   spec.summary       = "A Slack API wrapper written in Ruby."

--- a/lib/laziness/version.rb
+++ b/lib/laziness/version.rb
@@ -1,3 +1,3 @@
-module Slack
+module Laziness
   VERSION = "0.1.8"
 end


### PR DESCRIPTION
Wrap with the `Laziness` module instead of `Slack` so that it can be used with the [slack-ruby-client](https://github.com/dblock/slack-ruby-client).
