### PR TITLE
Change client to webclient

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+ruby:
+  config_file: .ruby-style.yml
+
+fail_on_violations: true

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -99,7 +99,10 @@ Style/SingleLineMethods:
   Enabled: false
   AllowIfMethodIsEmpty: true
 Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: false
+  Description: Use a space around equals in parameter defaults
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
+  Enabled: true
+  EnforcedStyle: no_space
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,0 +1,245 @@
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/schema.rb"
+  UseCache: false
+Style/CollectionMethods:
+  Description: Preferred collection methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    find: detect
+    find_all: select
+    reduce: inject
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+Style/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+  MaxLineLength: 80
+Style/OptionHash:
+  Description: Don't use option hashes when you can use keyword arguments.
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
+  Enabled: false
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Style/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: true
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  NamePrefixBlacklist:
+  - is_
+  Exclude:
+  - spec/**/*
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
+  Enabled: false
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  Enabled: false
+  EnforcedStyle: semantic
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+Style/SingleLineBlockParams:
+  Description: Enforces the names of some block params.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#reduce-blocks
+  Enabled: false
+  Methods:
+  - reduce:
+    - a
+    - e
+  - inject:
+    - a
+    - e
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
+  Enabled: false
+  AllowIfMethodIsEmpty: true
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: true
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/StringLiteralsInInterpolation:
+  Description: Checks if uses of quotes inside expressions in interpolated strings
+    match the configured preference.
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: false
+  Max: 15
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: false
+  CountComments: false
+  Max: 100
+Metrics/ModuleLength:
+  CountComments: false
+  Max: 100
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Description: A complexity metric that is strongly correlated to the number of test
+    cases needed to validate a method.
+  Enabled: false
+  Max: 6
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: false
+  CountComments: false
+  Max: 10
+Metrics/ParameterLists:
+  Description: Avoid parameter lists longer than three or four parameters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
+  Enabled: false
+  Max: 5
+  CountKeywordArgs: true
+Metrics/PerceivedComplexity:
+  Description: A complexity metric geared towards measuring complexity for a human
+    reader.
+  Enabled: false
+  Max: 7
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
+  Enabled: false
+  AllowSafeAssignment: true
+Style/InlineComment:
+  Description: Avoid inline comments.
+  Enabled: false
+Style/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Style/Alias:
+  Description: Use alias_method instead of alias.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
+  Enabled: false
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang
+  Enabled: false
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: false
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
+  Enabled: false
+Style/ModuleFunction:
+  Description: Checks for usage of `extend self` in modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
+  Enabled: false
+Style/OneLineConditional:
+  Description: Favor the ternary operator(?:) over if/then/else/end constructs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
+  Enabled: false
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
+  Enabled: false
+Style/Send:
+  Description: Prefer `Object#__send__` or `Object#public_send` to `send`, as `send`
+    may overlap with existing methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#prefer-public-send
+  Enabled: false
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
+  Enabled: false
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in
+    strings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
+  Enabled: false
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
+  Enabled: false
+Lint/EachWithObjectArgument:
+  Description: Check for immutable argument given to each_with_object.
+  Enabled: true
+Lint/HandleExceptions:
+  Description: Don't suppress exception.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralInCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The [Slack Web API](https://api.slack.com/web) is made up of HTTP RPC-style meth
 You start by creating a `Client` with the access token you want to use. You can make calls to each [type](https://api.slack.com/types) using the [methods](https://api.slack.com/methods).
 
 ```
-client = Slack.client(access_token: "your-access-token")
+client = Slack.web_client(access_token: "your-access-token")
 ```
 
 ### Channels

--- a/lib/laziness.rb
+++ b/lib/laziness.rb
@@ -17,7 +17,7 @@ require 'laziness/user'
 
 module Slack
   class << self
-    def client(attributes={})
+    def web_client(attributes={})
       Slack::Client.new(attributes[:access_token])
     end
   end

--- a/lib/laziness.rb
+++ b/lib/laziness.rb
@@ -1,19 +1,19 @@
-require 'laziness/version'
-require 'laziness/api'
-require 'laziness/base'
-require 'laziness/auth'
-require 'laziness/channel'
-require 'laziness/chat'
-require 'laziness/web_client'
-require 'laziness/errors'
-require 'laziness/group'
-require 'laziness/message'
-require 'laziness/oauth'
-require 'laziness/observer'
-require 'laziness/real_time_client'
-require 'laziness/registry'
-require 'laziness/session'
-require 'laziness/user'
+require "laziness/version"
+require "laziness/api"
+require "laziness/base"
+require "laziness/auth"
+require "laziness/channel"
+require "laziness/chat"
+require "laziness/web_client"
+require "laziness/errors"
+require "laziness/group"
+require "laziness/message"
+require "laziness/oauth"
+require "laziness/observer"
+require "laziness/real_time_client"
+require "laziness/registry"
+require "laziness/session"
+require "laziness/user"
 
 module Slack
   class << self

--- a/lib/laziness.rb
+++ b/lib/laziness.rb
@@ -4,7 +4,7 @@ require 'laziness/base'
 require 'laziness/auth'
 require 'laziness/channel'
 require 'laziness/chat'
-require 'laziness/client'
+require 'laziness/web_client'
 require 'laziness/errors'
 require 'laziness/group'
 require 'laziness/message'
@@ -18,7 +18,7 @@ require 'laziness/user'
 module Slack
   class << self
     def web_client(attributes={})
-      Slack::Client.new(attributes[:access_token])
+      Slack::WebClient.new(attributes[:access_token])
     end
   end
 end

--- a/lib/laziness/web_client.rb
+++ b/lib/laziness/web_client.rb
@@ -1,5 +1,5 @@
 module Slack
-  class Client
+  class WebClient
     attr_reader :access_token
 
     def initialize(access_token=nil)

--- a/spec/laziness/client_spec.rb
+++ b/spec/laziness/client_spec.rb
@@ -1,9 +1,9 @@
 describe Slack::Client do
   it "returns a new client" do
-    expect(Slack.client(access_token: "blah")).to be_instance_of Slack::Client
+    expect(Slack.web_client(access_token: "blah")).to be_instance_of Slack::Client
   end
 
   it "assigns the access token" do
-    expect(Slack.client(access_token: "blah").access_token).to eq "blah"
+    expect(Slack.web_client(access_token: "blah").access_token).to eq "blah"
   end
 end

--- a/spec/laziness/errors_spec.rb
+++ b/spec/laziness/errors_spec.rb
@@ -1,6 +1,6 @@
 describe 'API errors' do
   let(:access_token) { "12345" }
-  subject { Slack::Client.new access_token }
+  subject { Slack::WebClient.new access_token }
 
   # user_not_visible - The requested user is not visible to the calling user
 

--- a/spec/laziness/web_client_spec.rb
+++ b/spec/laziness/web_client_spec.rb
@@ -1,6 +1,7 @@
 describe Slack::WebClient do
   it "returns a new client" do
-    expect(Slack.web_client(access_token: "blah")).to be_instance_of Slack::WebClient
+    expect(Slack.web_client(access_token: "blah")).to \
+      be_instance_of Slack::WebClient
   end
 
   it "assigns the access token" do

--- a/spec/laziness/web_client_spec.rb
+++ b/spec/laziness/web_client_spec.rb
@@ -1,6 +1,6 @@
-describe Slack::Client do
+describe Slack::WebClient do
   it "returns a new client" do
-    expect(Slack.web_client(access_token: "blah")).to be_instance_of Slack::Client
+    expect(Slack.web_client(access_token: "blah")).to be_instance_of Slack::WebClient
   end
 
   it "assigns the access token" do


### PR DESCRIPTION
In order to make the difference even more granular, change the `Slack::Client` to `Slack::WebClient` so `Slack::RealTimeClient` makes more sense.

**NOT READY FOR MERGING YET**
