### PR TITLE
Hotfix nil pager

### DIFF
--- a/lib/laziness/pager.rb
+++ b/lib/laziness/pager.rb
@@ -5,7 +5,7 @@ module Slack
     attr_reader :cursor, :limit, :page
 
     def initialize(page)
-      @page = page.dup
+      @page = page
       @limit = @page[:limit] unless empty?
     end
 

--- a/lib/laziness/version.rb
+++ b/lib/laziness/version.rb
@@ -1,3 +1,3 @@
 module Laziness
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/spec/laziness/pager_spec.rb
+++ b/spec/laziness/pager_spec.rb
@@ -6,6 +6,10 @@ describe Slack::Pager do
       expect(described_class.new(page).page).to eq page
     end
 
+    it "can initialize with a nil page" do
+      expect(described_class.new(nil).page).to be_nil
+    end
+
     it "saves the limit" do
       expect(described_class.new(page).limit).to eq 20
     end


### PR DESCRIPTION
Fixes an issue with `0.2.5` when passing in a nil `page` to the `Pager`. When trying to `dup` nil, it would raise `TypeError`.